### PR TITLE
refactor(deps): pin dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "eslintplugin"
   ],
   "devDependencies": {
-    "@invisible/publish": "^1.1.6",
-    "docdash": "^0.4.0",
-    "eslint": "^4.7.1",
-    "jsdoc": "^3.5.4",
-    "nsp": "^2.8.1",
-    "yarn": "^1.1.0"
+    "@invisible/publish": "1.1.6",
+    "docdash": "0.4.0",
+    "eslint": "4.8.0",
+    "jsdoc": "3.5.5",
+    "nsp": "2.8.1",
+    "yarn": "1.1.0"
   },
   "repository": "git@github.com:invisible-tech/inv-lint.git",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@invisible/eslint-config",
   "license": "MIT",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Invisible Rules",
   "engines": {
     "node": "^8.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@invisible/publish@^1.1.6":
+"@invisible/publish@1.1.6":
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/@invisible/publish/-/publish-1.1.6.tgz#f9cdc613e9f5250b1f2afe4ceda9c8f137ecae88"
   dependencies:
@@ -272,7 +272,7 @@ del@^2.0.2:
     pinkie-promise "^2.0.0"
     rimraf "^2.2.8"
 
-docdash@^0.4.0:
+docdash@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/docdash/-/docdash-0.4.0.tgz#05c3a50d83189981699ee0c076d3a3950db7ec00"
 
@@ -382,9 +382,9 @@ eslint-scope@^3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint@^4.7.1:
-  version "4.7.2"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.7.2.tgz#ff6f5f5193848a27ee9b627be3e73fb9cb5e662e"
+eslint@4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.8.0.tgz#229ef0e354e0e61d837c7a80fdfba825e199815e"
   dependencies:
     ajv "^5.2.0"
     babel-code-frame "^6.22.0"
@@ -717,7 +717,7 @@ jschardet@^1.4.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.5.1.tgz#c519f629f86b3a5bedba58a88d311309eec097f9"
 
-jsdoc@^3.5.4:
+jsdoc@3.5.5:
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/jsdoc/-/jsdoc-3.5.5.tgz#484521b126e81904d632ff83ec9aaa096708fa4d"
   dependencies:
@@ -859,7 +859,7 @@ normalize-package-data@^2.3.2:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
-nsp@^2.8.1:
+nsp@2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/nsp/-/nsp-2.8.1.tgz#436e3f13869e0610d3a38f59d55f9b353cc32817"
   dependencies:
@@ -1303,6 +1303,6 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
-yarn@^1.1.0:
+yarn@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.1.0.tgz#f2da9340490236b6c56de305b1c21a8a19c433c3"


### PR DESCRIPTION
<p>This Pull Request renovates the package group "Pin Dependencies".</p>
<ul>
<li><a href="https://github.com/yarnpkg/yarn">yarn</a>: from <code>^1.1.0</code> to <code>1.1.0</code></li>
<li><a href="https://github.com/nodesecurity/nsp">nsp</a>: from <code>^2.8.1</code> to <code>2.8.1</code></li>
<li><a href="https://github.com/jsdoc3/jsdoc">jsdoc</a>: from <code>^3.5.4</code> to <code>3.5.5</code></li>
<li><a href="https://github.com/eslint/eslint">eslint</a>: from <code>^4.7.1</code> to <code>4.8.0</code></li>
<li><a href="https://github.com/clenemt/docdash">docdash</a>: from <code>^0.4.0</code> to <code>0.4.0</code></li>
<li>@&#8203;invisible/publish](<a href="https://github.com/invisible-tech/publish):">https://github.com/invisible-tech/publish):</a> from <code>^1.1.6</code> to <code>1.1.6</code></li>
</ul>
<p><br /></p>
<hr />
<p>This PR has been generated by <a href="https://renovateapp.com">Renovate Bot</a>.</p>