### PR TITLE
feat: add no-warning-comments rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,6 +49,7 @@
     "no-underscore-dangle": "off",
     "no-unused-vars": ["error", { "args": "after-used", "vars": "all" }],
     "no-use-before-define": "off",
+    "no-warning-comments": ["error"],
     "one-var": [ "error", { "initialized": "never", "uninitialized": "always" }],
     "one-var-declaration-per-line": ["error", "initializations"],
     "object-curly-newline": ["error", { "consistent": true }],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@invisible/eslint-config",
   "license": "MIT",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Invisible Rules",
   "engines": {
     "node": "^8.5.0"


### PR DESCRIPTION
Since we already agree that we should eliminate `todo` comments, we should automate the enforcement of this.