### PR TITLE
Chore: remove sort-keys rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -66,7 +66,6 @@
     "require-yield": "off",
     "semi": ["error","never"],
     "semi-style": ["error", "first"],
-    "sort-keys": [ "error", "asc", { "caseSensitive": true, "natural": false } ],
     "space-unary-ops": ["error", {
       "nonwords": false,
       "overrides": { "!": true },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@invisible/eslint-config",
   "license": "MIT",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Invisible Rules",
   "engines": {
     "node": "^8.5.0"


### PR DESCRIPTION
On most cases it makes sense to have `sort-keys` rule, but, in a case like below it is pretty logical to not sort.

```
const options = {
     method: 'PUT',
     path: `/threads/${thread.id}`,
     body: { label_ids: labelIds, unread: false },
   }
```